### PR TITLE
Deduplicate requests and add functions to extract from schema.org data model and RT scoreboard

### DIFF
--- a/rottentomatoes/standalone.py
+++ b/rottentomatoes/standalone.py
@@ -146,7 +146,7 @@ def rating(movie_name: str, content: str = None) -> str:
         content = _request(movie_name)
     
     location_key = content.find('"contentRating":"')
-    rating_block_location = location_key + len('"audienceScore":"')
+    rating_block_location = location_key + len('"contentRating":"')
     rating_block = content[rating_block_location:rating_block_location+5]
 
     # Split and parse


### PR DESCRIPTION
This PR cleans up a fair bit of duplicated code for better readability.

- HTTP requests are now called via the `_request(movie_name)` function, where originally it didn't appear to be used at all
- Logic to extract data from raw RT data is now done via the `_extract(content)` function
- Since much of the RT data that needed to be extracted was found in either the schema.org data model or the RT scoreboard data (which can be parsed in JSON), this can be retrieved via the `_get_schema_json_ld(content)` and `_get_score_details(content)` functions respectively