### PR TITLE
Improve deps in testing workflows

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,7 +38,7 @@ jobs:
         run: pip install -U pip wheel
 
       - name: Install deps
-        run: pip install -r requirements.txt
+        run: pip install .
 
       - name: Install test deps
         run: pip install pytest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
         run: pip install -U pip setuptools wheel
 
       - name: Install deps
-        run: pip install -r requirements.txt
+        run: pip install .
 
       - name: Install test deps
         run: pip install pytest


### PR DESCRIPTION
Install deps by installing package from source, as opposed to installing not-needed requirements for dev and server.